### PR TITLE
Reconfigure VM timeout

### DIFF
--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -1,0 +1,8 @@
+# Documenting differences between this repo and the Official Hasishcorp
+
+The purpose of this document is to record any differences in this repo compared to the official Hashicorp Terraform vsphere provider.
+
+| Tag | Change |
+|-----|--------|
+| v.0.0.2 | Added support for 64 disks per scsi controller. |
+| v.0.0.3 | Add reconfigure_timeout to allow user defined timeouts for long reconfigure operations, such as adding multiple and/or large disks. |

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -390,7 +390,8 @@ func recommendSDRS(client *govmomi.Client, sps types.StoragePlacementSpec, timeo
 }
 
 func applySDRS(client *govmomi.Client, placement *types.StoragePlacementResult, timeout time.Duration) (*object.VirtualMachine, error) {
-	log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q)", placement.Recommendations[0].Type)
+	// log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q)", placement.Recommendations[0].Type)
+	log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q, timeout %d)", placement.Recommendations[0].Type, timeout)
 	srm := object.NewStorageResourceManager(client.Client)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -295,6 +295,7 @@ func ReconfigureVM(
 	client *govmomi.Client,
 	vm *object.VirtualMachine,
 	spec types.VirtualMachineConfigSpec,
+	timeout int,
 	pod *object.StoragePod,
 ) error {
 	sdrsEnabled, err := StorageDRSEnabled(pod)
@@ -320,7 +321,7 @@ func ReconfigureVM(
 		ConfigSpec: &spec,
 	}
 
-	_, err = recommendAndApplySDRS(client, sps, provider.DefaultAPITimeout)
+	_, err = recommendAndApplySDRS(client, sps, time.Minute*time.Duration(timeout))
 	return err
 }
 
@@ -390,8 +391,7 @@ func recommendSDRS(client *govmomi.Client, sps types.StoragePlacementSpec, timeo
 }
 
 func applySDRS(client *govmomi.Client, placement *types.StoragePlacementResult, timeout time.Duration) (*object.VirtualMachine, error) {
-	// log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q)", placement.Recommendations[0].Type)
-	log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q, timeout %d)", placement.Recommendations[0].Type, timeout)
+	log.Printf("[DEBUG] Applying Storage DRS recommendations (type: %q)", placement.Recommendations[0].Type)
 	srm := object.NewStorageResourceManager(client.Client)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -145,6 +145,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				},
 			},
 		},
+		"reconfigure_timeout": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     5,
+			Description: "The amount of time, in minutes, to wait for reconfigure when making necessary updates to the virtual machine.",
+		},
 		"shutdown_wait_timeout": {
 			Type:         schema.TypeInt,
 			Optional:     true,
@@ -825,8 +831,8 @@ func resourceVSphereVirtualMachineUpdateReconfigureWithSDRS(
 	if err != nil {
 		return fmt.Errorf("error getting datastore cluster: %s", err)
 	}
-
-	err = storagepod.ReconfigureVM(client, vm, spec, pod)
+	timeout := d.Get("reconfigure_timeout").(int)
+	err = storagepod.ReconfigureVM(client, vm, spec, timeout, pod)
 	if err != nil {
 		return fmt.Errorf("error reconfiguring VM on datastore cluster %q: %s", pod.Name(), err)
 	}


### PR DESCRIPTION
Adding an extra timeout for reconfiguring VM's as it was not present, and the hard coded 5 minutes is not enough when adding multiple large disks etc.
