### PR TITLE
increasing maxitems of disks to 256 to allow for 64 disks per controller

### DIFF
--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -4,6 +4,7 @@ The purpose of this document is to record any differences in this repo compared 
 
 | Tag | Change |
 |-----|--------|
-| v.0.0.2 | Added support for 64 disks per scsi controller. |
-| v.0.0.3 | Add reconfigure_timeout to allow user defined timeouts for long reconfigure operations, such as adding multiple and/or large disks. |
+| v.0.0.5 | Increased maxitems per vm for disks to allow for 64 disks per controller. |
 | v.0.0.4 | Switch persist_sessions default to true. |
+| v.0.0.3 | Add reconfigure_timeout to allow user defined timeouts for long reconfigure operations, such as adding multiple and/or large disks. |
+| v.0.0.2 | Added support for 64 disks per scsi controller. |

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -222,7 +222,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Optional:    true,
 			Computed:    true,
 			Description: "A specification for a virtual disk device on this virtual machine.",
-			MaxItems:    60,
+			MaxItems:    256,
 			Elem:        &schema.Resource{Schema: virtualdevice.DiskSubresourceSchema()},
 		},
 		"network_interface": {


### PR DESCRIPTION
Although the code currently allows for adding 64 scsi devices per controller, the max overall was still set to 60 (15*4)
This change fixes that to allow 256 (64*4) maximum disks attached to a vm.